### PR TITLE
fixing count assertions from new php-cs-fixer update

### DIFF
--- a/tests/Zend/Controller/Action/Helper/FlashMessengerTest.php
+++ b/tests/Zend/Controller/Action/Helper/FlashMessengerTest.php
@@ -99,11 +99,11 @@ class Zend_Controller_Action_Helper_FlashMessengerTest extends PHPUnit\Framework
         $this->helper->addMessage('foo');
         $this->helper->addMessage('bar');
         $this->assertTrue($this->helper->hasMessages());
-        $this->assertEquals(2, count($this->helper));
+        $this->assertCount(2, $this->helper);
 
         $this->helper->clearMessages();
         $this->assertFalse($this->helper->hasMessages());
-        $this->assertEquals(0, count($this->helper));
+        $this->assertCount(0, $this->helper);
     }
 
     public function testDirectProxiesToAddMessage()
@@ -111,7 +111,7 @@ class Zend_Controller_Action_Helper_FlashMessengerTest extends PHPUnit\Framework
         $this->markTestSkipped();
         $this->helper->direct('foo');
         $this->assertTrue($this->helper->hasMessages());
-        $this->assertEquals(1, count($this->helper));
+        $this->assertCount(1, $this->helper);
     }
 
     /**
@@ -162,7 +162,7 @@ class Zend_Controller_Action_Helper_FlashMessengerTest extends PHPUnit\Framework
 
         // Ensure it didnt' clear the default namespace
         $defaultMessages = $this->helper->getCurrentMessages();
-        $this->assertEquals(1, count($defaultMessages));
+        $this->assertCount(1, $defaultMessages);
         $this->assertEquals('defaultmessage', array_pop($defaultMessages));
     }
 
@@ -186,11 +186,11 @@ class Zend_Controller_Action_Helper_FlashMessengerTest extends PHPUnit\Framework
         $this->assertTrue($helper->hasMessages());
 
         $defaultMessages = $helper->getMessages();
-        $this->assertEquals(1, count($defaultMessages));
+        $this->assertCount(1, $defaultMessages);
         $this->assertEquals('defaultmessage', array_pop($defaultMessages));
 
         $foobarMessages = $helper->getMessages('foobar');
-        $this->assertEquals(1, count($foobarMessages));
+        $this->assertCount(1, $foobarMessages);
         $this->assertEquals('testmessage', array_pop($foobarMessages));
     }
 }

--- a/tests/Zend/Controller/Action/HelperBroker/PriorityStackTest.php
+++ b/tests/Zend/Controller/Action/HelperBroker/PriorityStackTest.php
@@ -48,7 +48,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStackTest extends PHPUnit\Fram
     {
         $this->stack->push(new Zend_Controller_Action_Helper_ViewRenderer());
         $this->stack->push(new Zend_Controller_Action_Helper_Redirector());
-        $this->assertEquals(2, count($this->stack));
+        $this->assertCount(2, $this->stack);
         $iterator = $this->stack->getIterator();
         $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class(current($iterator)));
         next($iterator);
@@ -98,7 +98,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStackTest extends PHPUnit\Fram
         $this->stack->push(new Zend_Controller_Action_Helper_ViewRenderer());
         $this->stack->push(new Zend_Controller_Action_Helper_Redirector());
         unset($this->stack->ViewRenderer);
-        $this->assertEquals(1, count($this->stack));
+        $this->assertCount(1, $this->stack);
         $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class(current($this->stack->getIterator())));
         $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($this->stack->Redirector));
         $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($this->stack->offsetGet('Redirector')));

--- a/tests/Zend/Controller/Action/HelperBrokerTest.php
+++ b/tests/Zend/Controller/Action/HelperBrokerTest.php
@@ -202,7 +202,7 @@ class Zend_Controller_Action_HelperBrokerTest extends PHPUnit\Framework\TestCase
 
         $helpers = Zend_Controller_Action_HelperBroker::getExistingHelpers();
         $this->assertInternalType('array', $helpers);
-        $this->assertEquals(2, count($helpers));
+        $this->assertCount(2, $helpers);
         $this->assertContains('ViewRenderer', array_keys($helpers));
         $this->assertContains('Redirector', array_keys($helpers));
     }
@@ -214,7 +214,7 @@ class Zend_Controller_Action_HelperBrokerTest extends PHPUnit\Framework\TestCase
 
         $helpers = Zend_Controller_Action_HelperBroker::getExistingHelpers();
         $this->assertInternalType('array', $helpers);
-        $this->assertEquals(1, count($helpers));
+        $this->assertCount(1, $helpers);
     }
 
     public function testHelperPullsResponseFromRegisteredActionController()

--- a/tests/Zend/Controller/Plugin/ActionStackTest.php
+++ b/tests/Zend/Controller/Plugin/ActionStackTest.php
@@ -159,14 +159,14 @@ class Zend_Controller_Plugin_ActionStackTest extends PHPUnit\Framework\TestCase
         $plugin->pushStack($request1);
         $received = $plugin->getStack();
         $this->assertInternalType('array', $received);
-        $this->assertEquals(1, count($received));
+        $this->assertCount(1, $received);
         $this->assertSame($request1, $received[0]);
 
         $request2 = new Zend_Controller_Request_Simple();
         $plugin->pushStack($request2);
         $received = $plugin->getStack();
         $this->assertInternalType('array', $received);
-        $this->assertEquals(2, count($received));
+        $this->assertCount(2, $received);
         $this->assertSame($request2, $received[1]);
         $this->assertSame($request1, $received[0]);
     }
@@ -193,12 +193,12 @@ class Zend_Controller_Plugin_ActionStackTest extends PHPUnit\Framework\TestCase
                ->pushStack($request2)
                ->pushStack($request3);
         $stack = $plugin->getStack();
-        $this->assertEquals(3, count($stack));
+        $this->assertCount(3, $stack);
 
         $received = $plugin->popStack();
         $stack    = $plugin->getStack();
         $this->assertSame($request3, $received);
-        $this->assertEquals(2, count($stack));
+        $this->assertCount(2, $stack);
     }
 
     public function testPopEmptyStackReturnsFalse()
@@ -216,12 +216,12 @@ class Zend_Controller_Plugin_ActionStackTest extends PHPUnit\Framework\TestCase
         $plugin->pushStack($request1)
                ->pushStack($request2);
         $stack = $plugin->getStack();
-        $this->assertEquals(2, count($stack));
+        $this->assertCount(2, $stack);
 
         $received = $plugin->popStack();
         $stack    = $plugin->getStack();
         $this->assertSame($request1, $received);
-        $this->assertEquals(0, count($stack));
+        $this->assertCount(0, $stack);
     }
 
     public function testPopStackPopulatesControllerAndModuleFromRequestIfEmpty()
@@ -363,7 +363,7 @@ class Zend_Controller_Plugin_ActionStackTest extends PHPUnit\Framework\TestCase
 
         $plugin->postDispatch($request);
         $stack = $plugin->getStack();
-        $this->assertEquals(3, count($stack));
+        $this->assertCount(3, $stack);
     }
 }
 

--- a/tests/Zend/Controller/Plugin/BrokerTest.php
+++ b/tests/Zend/Controller/Plugin/BrokerTest.php
@@ -75,10 +75,10 @@ class Zend_Controller_Plugin_BrokerTest extends PHPUnit\Framework\TestCase
         $plugin = new Zend_Controller_Plugin_BrokerTest_TestPlugin();
         $broker->registerPlugin($plugin);
         $plugins = $broker->getPlugins();
-        $this->assertEquals(1, count($plugins));
+        $this->assertCount(1, $plugins);
         $broker->unregisterPlugin($plugin);
         $plugins = $broker->getPlugins();
-        $this->assertEquals(0, count($plugins));
+        $this->assertCount(0, $plugins);
     }
 
     public function testUnregisterPluginByClassName()
@@ -87,10 +87,10 @@ class Zend_Controller_Plugin_BrokerTest extends PHPUnit\Framework\TestCase
         $plugin = new Zend_Controller_Plugin_BrokerTest_TestPlugin();
         $broker->registerPlugin($plugin);
         $plugins = $broker->getPlugins();
-        $this->assertEquals(1, count($plugins));
+        $this->assertCount(1, $plugins);
         $broker->unregisterPlugin('Zend_Controller_Plugin_BrokerTest_TestPlugin');
         $plugins = $broker->getPlugins();
-        $this->assertEquals(0, count($plugins));
+        $this->assertCount(0, $plugins);
     }
 
     public function testGetPlugins()
@@ -99,7 +99,7 @@ class Zend_Controller_Plugin_BrokerTest extends PHPUnit\Framework\TestCase
         $plugin = new Zend_Controller_Plugin_BrokerTest_TestPlugin();
         $broker->registerPlugin($plugin);
         $plugins = $broker->getPlugins();
-        $this->assertEquals(1, count($plugins));
+        $this->assertCount(1, $plugins);
         $this->assertSame($plugin, $plugins[0]);
     }
 
@@ -133,7 +133,7 @@ class Zend_Controller_Plugin_BrokerTest extends PHPUnit\Framework\TestCase
 
         $retrieved = $broker->getPlugin('Zend_Controller_Plugin_BrokerTest_TestPlugin');
         $this->assertInternalType('array', $retrieved);
-        $this->assertEquals(2, count($retrieved));
+        $this->assertCount(2, $retrieved);
         $this->assertSame($plugin, $retrieved[0]);
         $this->assertSame($plugin2, $retrieved[1]);
     }

--- a/tests/Zend/Controller/Request/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Request/HttpTestCaseTest.php
@@ -92,7 +92,7 @@ class Zend_Controller_Request_HttpTestCaseTest extends PHPUnit\Framework\TestCas
         $this->request->setQuery('bat', 'bogus');
         $this->assertEquals('bogus', $this->request->getQuery('bat'));
         $test = $this->request->getQuery();
-        $this->assertEquals(4, count($test));
+        $this->assertCount(4, $test);
         foreach ($expected as $key => $value) {
             $this->assertEquals($value, $test[$key]);
         }
@@ -142,7 +142,7 @@ class Zend_Controller_Request_HttpTestCaseTest extends PHPUnit\Framework\TestCas
         $this->request->setPost('bat', 'bogus');
         $this->assertEquals('bogus', $this->request->getPost('bat'));
         $test = $this->request->getPost();
-        $this->assertEquals(4, count($test));
+        $this->assertCount(4, $test);
         foreach ($expected as $key => $value) {
             $this->assertEquals($value, $test[$key]);
         }
@@ -203,14 +203,14 @@ class Zend_Controller_Request_HttpTestCaseTest extends PHPUnit\Framework\TestCas
         $this->request->setHeaders($headers);
         $test = $this->request->getHeaders();
         $this->assertInternalType('array', $test);
-        $this->assertEquals(2, count($test));
+        $this->assertCount(2, $test);
         foreach ($headers as $key => $value) {
             $this->assertEquals($value, $this->request->getHeader($key));
         }
         $this->request->setHeader('X-Requested-With', 'XMLHttpRequest');
         $test = $this->request->getHeaders();
         $this->assertInternalType('array', $test);
-        $this->assertEquals(3, count($test));
+        $this->assertCount(3, $test);
         $this->assertEquals('XMLHttpRequest', $this->request->getHeader('X-Requested-With'));
     }
 

--- a/tests/Zend/Controller/Response/HttpTest.php
+++ b/tests/Zend/Controller/Response/HttpTest.php
@@ -91,11 +91,11 @@ class Zend_Controller_Response_HttpTest extends PHPUnit\Framework\TestCase
     {
         $this->_response->setHeader('Content-Type', 'text/xml');
         $headers = $this->_response->getHeaders();
-        $this->assertEquals(1, count($headers));
+        $this->assertCount(1, $headers);
 
         $this->_response->clearHeaders();
         $headers = $this->_response->getHeaders();
-        $this->assertEquals(0, count($headers));
+        $this->assertCount(0, $headers);
     }
 
     /**
@@ -503,7 +503,7 @@ class Zend_Controller_Response_HttpTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($this->_response->clearBody());
         $body = $this->_response->getBody(true);
         $this->assertInternalType('array', $body);
-        $this->assertEquals(0, count($body));
+        $this->assertCount(0, $body);
     }
 
     public function testClearBodySegment()
@@ -516,7 +516,7 @@ class Zend_Controller_Response_HttpTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($this->_response->clearBody('more'));
         $body = $this->_response->getBody(true);
         $this->assertInternalType('array', $body);
-        $this->assertEquals(2, count($body));
+        $this->assertCount(2, $body);
         $this->assertTrue(isset($body['some']));
         $this->assertTrue(isset($body['superfluous']));
     }

--- a/tests/Zend/Controller/Response/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Response/HttpTestCaseTest.php
@@ -94,7 +94,7 @@ class Zend_Controller_Response_HttpTestCaseTest extends PHPUnit\Framework\TestCa
                        ->setHeader('X-Foo-Bar', 'baz');
         $test = $this->response->sendHeaders();
         $this->assertInternalType('array', $test);
-        $this->assertEquals(3, count($test));
+        $this->assertCount(3, $test);
         $this->assertNotContains('Content-Type: text/xml', $test);
         $this->assertContains('Content-Type: text/html', $test);
         $this->assertContains('X-Foo-Bar: baz', $test);

--- a/tests/Zend/Controller/Router/RewriteTest.php
+++ b/tests/Zend/Controller/Router/RewriteTest.php
@@ -54,13 +54,13 @@ class Zend_Controller_Router_RewriteTest extends PHPUnit\Framework\TestCase
         $this->_router->addRoute('archive', new Zend_Controller_Router_Route('archive/:year', array('year' => '2006', 'controller' => 'archive', 'action' => 'show'), array('year' => '\d+')));
         $routes = $this->_router->getRoutes();
 
-        $this->assertEquals(1, count($routes));
+        $this->assertCount(1, $routes);
         $this->assertTrue($routes['archive'] instanceof Zend_Controller_Router_Route);
 
         $this->_router->addRoute('register', new Zend_Controller_Router_Route('register/:action', array('controller' => 'profile', 'action' => 'register')));
         $routes = $this->_router->getRoutes();
 
-        $this->assertEquals(2, count($routes));
+        $this->assertCount(2, $routes);
         $this->assertTrue($routes['register'] instanceof Zend_Controller_Router_Route);
     }
 
@@ -74,7 +74,7 @@ class Zend_Controller_Router_RewriteTest extends PHPUnit\Framework\TestCase
 
         $values = $this->_router->getRoutes();
 
-        $this->assertEquals(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertTrue($values['archive'] instanceof Zend_Controller_Router_Route);
         $this->assertTrue($values['register'] instanceof Zend_Controller_Router_Route);
     }
@@ -107,7 +107,7 @@ class Zend_Controller_Router_RewriteTest extends PHPUnit\Framework\TestCase
         $this->_router->removeRoute('archive');
 
         $routes = $this->_router->getRoutes();
-        $this->assertEquals(0, count($routes));
+        $this->assertCount(0, $routes);
 
         try {
             $route = $this->_router->removeRoute('archive');
@@ -341,7 +341,7 @@ class Zend_Controller_Router_RewriteTest extends PHPUnit\Framework\TestCase
         }
 
         $routes = $this->_router->getRoutes();
-        $this->assertEquals(0, count($routes));
+        $this->assertCount(0, $routes);
     }
 
     public function testDefaultRouteMatchedWithModules()

--- a/tests/Zend/Controller/Router/Route/RegexTest.php
+++ b/tests/Zend/Controller/Router/Route/RegexTest.php
@@ -69,7 +69,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/all', array('controller' => 'ctrl'));
         $values = $route->match('users/all');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('ctrl', $values['controller']);
     }
 
@@ -86,7 +86,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(.+)');
         $values = $route->match('users/martel');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('martel', $values[1]);
     }
 
@@ -95,7 +95,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(user_(\d+).html)');
         $values = $route->match('users/user_1354.html');
 
-        $this->assertSame(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertSame('user_1354.html', $values[1]);
         $this->assertSame('1354', $values[2]);
     }
@@ -110,7 +110,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
 
         $values = $route->match('users');
 
-        $this->assertSame(3, count($values));
+        $this->assertCount(3, $values);
         $this->assertSame('index', $values['module']);
         $this->assertSame('index', $values['controller']);
         $this->assertSame('users', $values['action']);
@@ -121,7 +121,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/?(.+)?', array(1 => 'martel'));
         $values = $route->match('users');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('martel', $values[1]);
     }
 
@@ -130,7 +130,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/?(.+)?', array(1 => 'martel'));
         $values = $route->match('users/vicki');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('vicki', $values[1]);
     }
 
@@ -139,7 +139,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(?P<username>.+)');
         $values = $route->match('users/martel');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('martel', $values[1]);
     }
 
@@ -148,7 +148,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(.+)', null, array(1 => 'username'));
         $values = $route->match('users/martel');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('martel', $values['username']);
     }
 
@@ -157,7 +157,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users(?:/(.+))?', array('username' => 'martel'), array(1 => 'username'));
         $values = $route->match('users');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('martel', $values['username']);
     }
 
@@ -166,7 +166,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(?P<name>.+)', null, array(1 => 'username'));
         $values = $route->match('users/martel');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('martel', $values['username']);
     }
 
@@ -175,7 +175,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(\w+)/?(?:p/(\d+))?', null, array(1 => 'username', 2 => 'page'));
         $values = $route->match('users/martel/p/1');
 
-        $this->assertSame(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertSame('martel', $values['username']);
         $this->assertSame('1', $values['page']);
     }
@@ -185,7 +185,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(\w+)/?(?:p/(\d+))?', null, array(1 => 'username', 2 => 'page'));
         $values = $route->match('users/martel');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('martel', $values['username']);
     }
 
@@ -194,7 +194,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(\w+)/?(?:p/(\d+))?', null, array(1 => 'username'));
         $values = $route->match('users/martel/p/1');
 
-        $this->assertSame(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertSame('martel', $values['username']);
         $this->assertSame('1', $values[2]);
     }
@@ -204,7 +204,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/?(.+)?', array(1 => 'martel'), array(1 => 'username'));
         $values = $route->match('users');
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('martel', $values['username']);
     }
 
@@ -213,7 +213,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(\w+)/?(?:p/(\d+))?', array(2 => '1'), array(1 => 'username'));
         $values = $route->match('users/martel/p/10');
 
-        $this->assertSame(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertSame('martel', $values['username']);
         $this->assertSame('10', $values[2]);
     }
@@ -223,7 +223,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/?(\w+)?/?(?:p/(\d+))?', array(2 => '1', 'username' => 'martel'), array(1 => 'username'));
         $values = $route->match('users');
 
-        $this->assertSame(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertSame('martel', $values['username']);
         $this->assertSame('1', $values[2]);
     }
@@ -233,7 +233,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(\w+)/?(?:p/(\d+))?', array('page' => '1', 'username' => 'martel'), array(1 => 'username', 2 => 'page'));
         $values = $route->match('users/martel');
 
-        $this->assertSame(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertSame('martel', $values['username']);
         $this->assertSame('1', $values['page']);
     }
@@ -243,7 +243,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
         $route  = new Zend_Controller_Router_Route_Regex('users/(\w+)/?(?:p/(\d+))?', array(2 => '1'), array(2 => 'page'));
         $values = $route->match('users/martel');
 
-        $this->assertSame(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertSame('martel', $values[1]);
         $this->assertSame('1', $values['page']);
     }
@@ -255,7 +255,7 @@ class Zend_Controller_Router_Route_RegexTest extends PHPUnit\Framework\TestCase
 
         // Matches both defaults but the one defined last is used
 
-        $this->assertSame(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertSame('vicki', $values['username']);
     }
 


### PR DESCRIPTION
php-cs-fixer update added these fixes, caught by travis cron build.

No changes to library code, just assertions in the tests.