### PR TITLE
Fixing a couple of failed tests on php 7.4 snapshot

### DIFF
--- a/src/Zend/Controller/Action.php
+++ b/src/Zend/Controller/Action.php
@@ -65,7 +65,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
 
     /**
      * View script suffix; defaults to 'phtml'
-     * @see {render()}
+     * @see Zend_Controller_Action::render()
      * @var string
      */
     public $viewSuffix = 'phtml';

--- a/src/Zend/Controller/Request/Http.php
+++ b/src/Zend/Controller/Request/Http.php
@@ -50,7 +50,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
 
     /**
      * REQUEST_URI
-     * @var string;
+     * @var string
      */
     protected $_requestUri;
 

--- a/tests/Zend/Controller/Action/HelperBroker/PriorityStackTest.php
+++ b/tests/Zend/Controller/Action/HelperBroker/PriorityStackTest.php
@@ -49,10 +49,10 @@ class Zend_Controller_Action_HelperBroker_PriorityStackTest extends PHPUnit\Fram
         $this->stack->push(new Zend_Controller_Action_Helper_ViewRenderer());
         $this->stack->push(new Zend_Controller_Action_Helper_Redirector());
         $this->assertCount(2, $this->stack);
-        $iterator = $this->stack->getIterator();
-        $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class(current($iterator)));
-        next($iterator);
-        $this->assertEquals('Zend_Controller_Action_Helper_ViewRenderer', get_class(current($iterator)));
+        $iterator = $this->stack->getIterator()->getIterator();
+        $this->assertEquals(Zend_Controller_Action_Helper_Redirector::class, get_class($iterator->current()));
+        $iterator->next();
+        $this->assertEquals(Zend_Controller_Action_Helper_ViewRenderer::class, get_class($iterator->current()));
     }
 
     public function testStackPrioritiesWithDefaults()
@@ -64,7 +64,6 @@ class Zend_Controller_Action_HelperBroker_PriorityStackTest extends PHPUnit\Fram
         $this->assertEquals(2, $this->stack->getHighestPriority());
         $this->assertEquals(1, $this->stack->getLowestPriority());
     }
-
 
     public function testStackMaintainsReturnsCorrectNextPriorityWithSetPriorities()
     {
@@ -99,9 +98,9 @@ class Zend_Controller_Action_HelperBroker_PriorityStackTest extends PHPUnit\Fram
         $this->stack->push(new Zend_Controller_Action_Helper_Redirector());
         unset($this->stack->ViewRenderer);
         $this->assertCount(1, $this->stack);
-        $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class(current($this->stack->getIterator())));
-        $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($this->stack->Redirector));
-        $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($this->stack->offsetGet('Redirector')));
-        $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($this->stack->offsetGet(2)));
+        $this->assertEquals(Zend_Controller_Action_Helper_Redirector::class, get_class($this->stack->getIterator()->getIterator()->current()));
+        $this->assertEquals(Zend_Controller_Action_Helper_Redirector::class, get_class($this->stack->Redirector));
+        $this->assertEquals(Zend_Controller_Action_Helper_Redirector::class, get_class($this->stack->offsetGet('Redirector')));
+        $this->assertEquals(Zend_Controller_Action_Helper_Redirector::class, get_class($this->stack->offsetGet(2)));
     }
 }


### PR DESCRIPTION
Have seen these failed tests for a while, decided to look into it.

Apparently in php 7.4 it's no longer possible to use the `current` php function on an object, and expect it to use the Traversable methods. Instead it traverses the public properties of the object (which is expected behavior in most cases).

More here: https://github.com/php/php-src/blob/07df6594b5c71b176b376aba8007bc33616bbfb0/UPGRADING#L75-L86
And more discussion in a bug report here: https://bugs.php.net/bug.php?id=77864

I decided to leave the code alone and just fix the tests in this case, as any code changes to resolve this are a BC break, and the code itself doesn't cause issues in PHP 7.4, but the way the tests were interfacing with the code was the issue. Technically a `getIterator` method should probably return an iterator, not an `ArrayObject` that has to then have `getIterator` called on it, but this change shouldn't break any implementations using this code (that code may break on php 7.4 though if using `current`, `next`, etc... on the return of `getIterator` directly).

Also fixing a couple of minor docblock issues that came up from testing a code analysis tool.