### PR TITLE
deprecating _getParam, some doc fixes, phpstan object crates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "diablomedia/zendframework1-exception": "^1.0.0",
         "diablomedia/zendframework1-config": "^1.0.0",
         "diablomedia/zendframework1-loader": "^1.0.0",
-        "diablomedia/zendframework1-registry": "^1.0.0",
+        "diablomedia/zendframework1-registry": "^1.0.2",
         "diablomedia/zendframework1-cache": "^1.0.0",
         "diablomedia/zendframework1-filter": "^1.0.0",
         "diablomedia/zendframework1-locale": "^1.0.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,9 @@ parameters:
     excludes_analyse:
         - %rootDir%/../../../tests/*
         - %rootDir%/../../../vendor/*
+    universalObjectCratesClasses:
+        - Zend_Config
+        - ArrayObject
     ignoreErrors:
         - '#Method Zend_Controller_Plugin_ActionStack::popStack\(\) invoked with 1 parameter, 0 required\.#'
         - '#Class Zend_Controller_Router_Route_Chain does not have a constructor and must be instantiated without any parameters\.#'

--- a/src/Zend/Controller/Action.php
+++ b/src/Zend/Controller/Action.php
@@ -292,7 +292,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * Set the Request object
      *
      * @param Zend_Controller_Request_Abstract $request
-     * @return Zend_Controller_Action
+     * @return self
      */
     public function setRequest(Zend_Controller_Request_Abstract $request)
     {
@@ -314,7 +314,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * Set the Response object
      *
      * @param Zend_Controller_Response_Abstract $response
-     * @return Zend_Controller_Action
+     * @return self
      */
     public function setResponse(Zend_Controller_Response_Abstract $response)
     {
@@ -326,7 +326,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * Set invocation arguments
      *
      * @param array $args
-     * @return Zend_Controller_Action
+     * @return self
      */
     protected function _setInvokeArgs(array $args = array())
     {
@@ -559,6 +559,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param string $paramName
      * @param mixed $default
      * @return mixed
+     * @deprecated Deprecated. Use getParam() instead.
      */
     protected function _getParam($paramName, $default = null)
     {
@@ -591,7 +592,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      *
      * @param string $paramName
      * @param mixed $value
-     * @return Zend_Controller_Action
+     * @return self
      * @deprecated Deprecated as of Zend Framework 1.7. Use
      *             setParam() instead.
      */
@@ -605,7 +606,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      *
      * @param string $paramName
      * @param mixed $value
-     * @return Zend_Controller_Action
+     * @return self
      */
     public function setParam($paramName, $value)
     {

--- a/tests/Zend/Controller/ActionTest.php
+++ b/tests/Zend/Controller/ActionTest.php
@@ -489,14 +489,14 @@ class Zend_Controller_ActionTest_TestController extends Zend_Controller_Action
 
     public function preDispatch()
     {
-        if (false !== ($param = $this->_getParam('prerun', false))) {
+        if (false !== ($param = $this->getParam('prerun', false))) {
             $this->getResponse()->appendBody("Prerun ran\n");
         }
     }
 
     public function postDispatch()
     {
-        if (false !== ($param = $this->_getParam('postrun', false))) {
+        if (false !== ($param = $this->getParam('postrun', false))) {
             $this->getResponse()->appendBody("Postrun ran\n");
         }
     }


### PR DESCRIPTION
It seems that most of the `_(get|set|has)` methods of the `Zend_Controller_Action` class were deprecated in favor of their non-underscore prefixed version in ZF 1.7, except for `_getParam`.  Adding a deprecation notice for that method as well so that static analyzers can complain about it.

Changed some `Zend_Controller_Action` return types to `self` to more accurately describe the return.

Toyed with bumping the phpstan level to 2, which is why I added the universal object crate config, but decided against going further with that for now (the crate options are fine to stay, as they'll be useful if the phpstan level is bumped).