### PR TITLE
Catch throwable instead of exception

### DIFF
--- a/src/Zend/Controller/Dispatcher/Standard.php
+++ b/src/Zend/Controller/Dispatcher/Standard.php
@@ -295,7 +295,7 @@ class Zend_Controller_Dispatcher_Standard extends Zend_Controller_Dispatcher_Abs
 
         try {
             $controller->dispatch($action);
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             // Clean output buffer on error
             $curObLevel = ob_get_level();
             if ($curObLevel > $obLevel) {

--- a/src/Zend/Controller/Front.php
+++ b/src/Zend/Controller/Front.php
@@ -278,7 +278,7 @@ class Zend_Controller_Front
     {
         try {
             $dir = new DirectoryIterator($path);
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             throw new Zend_Controller_Exception("Directory $path not readable", 0, $e);
         }
         foreach ($dir as $file) {
@@ -886,7 +886,7 @@ class Zend_Controller_Front
 
             try {
                 $router->route($this->_request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if ($this->throwExceptions()) {
                     throw $e;
                 }
@@ -929,7 +929,7 @@ class Zend_Controller_Front
                  */
                 try {
                     $dispatcher->dispatch($this->_request, $this->_response);
-                } catch (Exception $e) {
+                } catch (\Throwable $e) {
                     if ($this->throwExceptions()) {
                         throw $e;
                     }
@@ -941,7 +941,7 @@ class Zend_Controller_Front
                  */
                 $this->_plugins->postDispatch($this->_request);
             } while (!$this->_request->isDispatched());
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             if ($this->throwExceptions()) {
                 throw $e;
             }
@@ -954,7 +954,7 @@ class Zend_Controller_Front
          */
         try {
             $this->_plugins->dispatchLoopShutdown();
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             if ($this->throwExceptions()) {
                 throw $e;
             }

--- a/src/Zend/Controller/Plugin/Broker.php
+++ b/src/Zend/Controller/Plugin/Broker.php
@@ -229,7 +229,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->routeStartup($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -252,7 +252,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->routeShutdown($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -279,7 +279,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->dispatchLoopStartup($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -301,7 +301,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->preDispatch($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -325,7 +325,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->postDispatch($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -346,7 +346,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->dispatchLoopShutdown();
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {

--- a/src/Zend/Controller/Response/Abstract.php
+++ b/src/Zend/Controller/Response/Abstract.php
@@ -39,7 +39,7 @@ abstract class Zend_Controller_Response_Abstract
 
     /**
      * Exception stack
-     * @var Exception[]
+     * @var \Throwable[]
      */
     protected $_exceptions = array();
 
@@ -585,10 +585,10 @@ abstract class Zend_Controller_Response_Abstract
     /**
      * Register an exception with the response
      *
-     * @param Exception $e
+     * @param \Throwable $e
      * @return Zend_Controller_Response_Abstract
      */
-    public function setException(Exception $e)
+    public function setException(\Throwable $e)
     {
         $this->_exceptions[] = $e;
         return $this;

--- a/tests/Zend/Controller/FrontTest.php
+++ b/tests/Zend/Controller/FrontTest.php
@@ -655,4 +655,17 @@ class Zend_Controller_FrontTest extends PHPUnit\Framework\TestCase
 
         $this->assertFalse(Zend_Controller_Action_HelperBroker::hasHelper('viewRenderer'));
     }
+
+
+    public function testDispatcherHandlesTypeError()
+    {
+        $request = new Zend_Controller_Request_Http('http://example.com/index/type-error');
+
+        $this->_controller->setRequest($request);
+        $response = new Zend_Controller_Response_Cli();
+        $this->_controller->throwExceptions(false);
+        $this->_controller->dispatch($request, $response);
+
+        $this->assertContains('Type error action called', $this->_controller->getResponse()->getBody());
+    }
 }

--- a/tests/Zend/Controller/FrontTest.php
+++ b/tests/Zend/Controller/FrontTest.php
@@ -656,7 +656,6 @@ class Zend_Controller_FrontTest extends PHPUnit\Framework\TestCase
         $this->assertFalse(Zend_Controller_Action_HelperBroker::hasHelper('viewRenderer'));
     }
 
-
     public function testDispatcherHandlesTypeError()
     {
         $request = new Zend_Controller_Request_Http('http://example.com/index/type-error');
@@ -667,5 +666,18 @@ class Zend_Controller_FrontTest extends PHPUnit\Framework\TestCase
         $this->_controller->dispatch($request, $response);
 
         $this->assertContains('Type error action called', $this->_controller->getResponse()->getBody());
+    }
+
+    public function testDispatcherPassesTypeErrorThroughWhenThrowExceptions()
+    {
+        $request = new Zend_Controller_Request_Http('http://example.com/index/type-error');
+
+        $this->_controller->setRequest($request);
+        $response = new Zend_Controller_Response_Cli();
+        $this->_controller->throwExceptions(true);
+
+        $this->expectExceptionMessage('Return value of IndexController::produceTypeError() must be an instance of IndexController, instance of stdClass returned');
+        $this->expectException(TypeError::class);
+        $this->_controller->dispatch($request, $response);
     }
 }

--- a/tests/Zend/Controller/_files/IndexController.php
+++ b/tests/Zend/Controller/_files/IndexController.php
@@ -94,4 +94,15 @@ class IndexController extends Zend_Controller_Action
     {
         $this->_response->appendBody('Reset action called');
     }
+
+    public function typeErrorAction()
+    {
+        $this->_response->appendBody('Type error action called');
+        $this->produceTypeError();
+    }
+
+    private function produceTypeError(): self
+    {
+        return new stdClass();
+    }
 }


### PR DESCRIPTION
All catch-all statements across ZF1 are catching `Exception`. That means that anything that's not `Exception` (for example `TypeError`) is not caught in ErrorController. To fix this this needs to be fixed on multiple places and `Exception` needs to be replaced with `\Throwable`. 